### PR TITLE
Turn on to last state instead of heat mode.

### DIFF
--- a/custom_components/jcihitachi_tw/climate.py
+++ b/custom_components/jcihitachi_tw/climate.py
@@ -224,6 +224,10 @@ class JciHitachiClimateEntity(JciHitachiEntity, ClimateEntity):
             support_flags |= SUPPORT_SWING_MODE
         return support_flags
 
+    def turn_on(self):
+        self.put_queue("power", 1, self._peripheral.name)
+        self.update()
+        
     def set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
 


### PR DESCRIPTION
When calling home assistant "Turn On" service the AC always defaults to heat mode. This change makes home assistant just turn on and use the last mode of the AC. Needed when using Alexa to simply Turn on the AC instead of using the buttons from the HA interface.