### PR TITLE
fix: fix status logging error

### DIFF
--- a/custom_components/jcihitachi_tw/__init__.py
+++ b/custom_components/jcihitachi_tw/__init__.py
@@ -97,7 +97,7 @@ async def async_setup(hass, config):
             raise UpdateFailed(f"Error communicating with API: {err}")
         
         _LOGGER.debug(
-            f"Latest data: {[(name, value.legacy_status) for name, value in hass.data[UPDATED_DATA].items()]}")
+            f"Latest data: {[(name, value.status) for name, value in hass.data[UPDATED_DATA].items()]}")
 
     coordinator = DataUpdateCoordinator(
         hass,


### PR DESCRIPTION
## Problems

the class `JciHitachiDH` doesn't have the attribute `legacy_status`

### Expected log:
```
2022-03-06 23:37:49 DEBUG (MainThread) [custom_components.jcihitachi_tw] Latest data: [('RD-200HH', {'power': 'on', 'mode': 'clothes_dry', 'target_humidity': 30, 'indoor_humidity': 54, 'wind_swingable': 'on', 'water_full_warning': 'off', 'clean_filter_notify': 'disabled', 'air_purify_level': 'unsupported', 'air_speed': 'high', 'side_vent': 'off', 'sound_control': 'silent', 'error_code': 0, 'mold_prev': 'off', 'power_kwh': 0.6, 'air_quality_value': -1, 'air_quality_level': 'unsupported', 'pm25_value': 2, 'display_brightness': 'bright', 'odor_level': 'middle', 'air_cleaning_filter': 'enabled'})]
```

### Actual log:
```
2022-03-06 23:41:13 DEBUG (MainThread) [custom_components.jcihitachi_tw] Unexpected error fetching jcihitachi_tw data: 'JciHitachiDH' object has no attribute 'legacy_status'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 187, in _async_refresh
    self.data = await self._async_update_data()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 147, in _async_update_data
    return await self.update_method()
  File "/config/custom_components/jcihitachi_tw/__init__.py", line 100, in async_update_data
    f"Latest data: {[(name, value.legacy_status) for name, value in hass.data[UPDATED_DATA].items()]}")
  File "/config/custom_components/jcihitachi_tw/__init__.py", line 100, in <listcomp>
    f"Latest data: {[(name, value.legacy_status) for name, value in hass.data[UPDATED_DATA].items()]}")
AttributeError: 'JciHitachiDH' object has no attribute 'legacy_status'
```