### PR TITLE
Add Jci Hitachi Dehumidifier Light Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ A home assistant integration for controlling Jci Hitachi devices, using [LibJciH
   - Air cleaning filter setting 空氣清淨濾網設定
   - Power consumption 用電統計 (supports HA core v2021.9.0+)
   - Monthly power consumption 月用電統計
+  - Display brightness 顯示器亮度
   - ~~Sound control 聲音控制~~ (Only supported by LibJciHitachi)
-  - ~~Display brightness 顯示器亮度~~ (Only supported by LibJciHitachi)
   - ~~Side vent 側吹~~ (Only supported by LibJciHitachi)
 - Hitachi Heat Exchanger 日立全熱交換機
   - Power 電源

--- a/custom_components/jcihitachi_tw/__init__.py
+++ b/custom_components/jcihitachi_tw/__init__.py
@@ -19,7 +19,7 @@ from .const import (API, CONF_DEVICES, CONF_EMAIL, CONF_PASSWORD, CONF_RETRY,
                     UPDATED_DATA)
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS = ["binary_sensor", "climate", "fan", "humidifier", "number", "sensor", "switch"]
+PLATFORMS = ["binary_sensor", "climate", "fan", "humidifier", "number", "sensor", "switch", "light"]
 DATA_UPDATE_INTERVAL = timedelta(seconds=30)
 BASE_TIMEOUT = 5
 

--- a/custom_components/jcihitachi_tw/light.py
+++ b/custom_components/jcihitachi_tw/light.py
@@ -1,0 +1,94 @@
+import logging
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    SUPPORT_BRIGHTNESS,
+    LightEntity,
+)
+
+from . import API, COORDINATOR, DOMAIN, UPDATED_DATA, JciHitachiEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _async_setup(hass, async_add):
+    api = hass.data[DOMAIN][API]
+    coordinator = hass.data[DOMAIN][COORDINATOR]
+
+    for thing in api.things.values():
+        if thing.type == "DH":
+            async_add(
+                [JciHitachiDehumidifierLightEntity(thing, coordinator)],
+                update_before_add=True,
+            )
+
+
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+    await _async_setup(hass, async_add_entities)
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    await _async_setup(hass, async_add_devices)
+
+
+class JciHitachiDehumidifierLightEntity(JciHitachiEntity, LightEntity):
+    def __init__(self, thing, coordinator):
+        super().__init__(thing, coordinator)
+
+    @property
+    def unique_id(self):
+        return f"{self._thing.gateway_mac_address}_dehumidifier_light"
+
+    @property
+    def name(self):
+        return f"{self._thing.name} panel LED"
+
+    @property
+    def supported_features(self):
+        return SUPPORT_BRIGHTNESS
+
+    @property
+    def is_on(self):
+        """Return true if the entity is on"""
+        status = self.hass.data[DOMAIN][UPDATED_DATA][self._thing.name]
+        if status:
+            if status.display_brightness == "all_off":
+                return False
+            else:
+                return True
+
+        _LOGGER.error("Missing is_on.")
+        return None
+
+    @property
+    def brightness(self):
+        status = self.hass.data[DOMAIN][UPDATED_DATA][self._thing.name]
+        if status:
+            brightness_mapping = {
+                "bright": 255,
+                "dark": 170,
+                "off": 85,
+                "all_off": 0,
+            }
+            return brightness_mapping.get(status.display_brightness, 0)
+
+        _LOGGER.error("Missing brightness.")
+        return 0
+
+    def turn_on(self, **kwargs):
+        _LOGGER.debug(f"Turn {self.name} on")
+        brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
+        if brightness > 170:
+            brightness_value = 0
+        elif brightness <= 170 and brightness > 85:
+            brightness_value = 1
+        elif brightness <= 85 and brightness > 3:
+            brightness_value = 2
+        else:
+            brightness_value = 3
+        self.put_queue(status_name="display_brightness", status_value=brightness_value)
+        self.update()
+
+    def turn_off(self, **kwargs):
+        _LOGGER.debug(f"Turn {self.name} off")
+        self.put_queue(status_name="display_brightness", status_value=3)
+        self.update()

--- a/custom_components/jcihitachi_tw/light.py
+++ b/custom_components/jcihitachi_tw/light.py
@@ -31,6 +31,13 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 
 
 class JciHitachiDehumidifierLightEntity(JciHitachiEntity, LightEntity):
+    brightness_mapping = {
+        "bright": 255,
+        "dark": 170,
+        "off": 85,
+        "all_off": 0,
+    }
+
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
 
@@ -63,13 +70,7 @@ class JciHitachiDehumidifierLightEntity(JciHitachiEntity, LightEntity):
     def brightness(self):
         status = self.hass.data[DOMAIN][UPDATED_DATA][self._thing.name]
         if status:
-            brightness_mapping = {
-                "bright": 255,
-                "dark": 170,
-                "off": 85,
-                "all_off": 0,
-            }
-            return brightness_mapping.get(status.display_brightness, 0)
+            return self.brightness_mapping.get(status.display_brightness, 0)
 
         _LOGGER.error("Missing brightness.")
         return 0
@@ -78,17 +79,19 @@ class JciHitachiDehumidifierLightEntity(JciHitachiEntity, LightEntity):
         _LOGGER.debug(f"Turn {self.name} on")
         brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
         if brightness > 170:
-            brightness_value = 0
+            brightness_value = "bright"
         elif brightness <= 170 and brightness > 85:
-            brightness_value = 1
+            brightness_value = "dark"
         elif brightness <= 85 and brightness > 3:
-            brightness_value = 2
+            brightness_value = "off"
         else:
-            brightness_value = 3
-        self.put_queue(status_name="display_brightness", status_value=brightness_value)
+            brightness_value = "all_off"
+        self.put_queue(
+            status_name="display_brightness", status_str_value=brightness_value
+        )
         self.update()
 
     def turn_off(self, **kwargs):
         _LOGGER.debug(f"Turn {self.name} off")
-        self.put_queue(status_name="display_brightness", status_value=3)
+        self.put_queue(status_name="display_brightness", status_str_value="all_off")
         self.update()


### PR DESCRIPTION
- Added support for controlling Jci Hitachi dehumidifier panel LED brightness within Home Assistant.
- Created a new 'light' platform to handle brightness control for dehumidifier LEDs.
- Updated README to reflect the addition of 'Display brightness' feature.
- Modified '__init__.py' to include 'light' in the list of supported platforms for the integration.

Just so you know, there was a request of this (#60 機體顯示亮度支援) a couple of months ago,
and it's implemented in this PR.