### PR TITLE
Add current_humidity for dehumidifier

### DIFF
--- a/custom_components/jcihitachi_tw/humidifier.py
+++ b/custom_components/jcihitachi_tw/humidifier.py
@@ -69,8 +69,16 @@ class JciHitachiDehumidifierEntity(JciHitachiEntity, HumidifierEntity):
         return self._supported_features
 
     @property
+    def current_humidity(self):
+        """Return the current humidity."""
+        status = self.hass.data[DOMAIN][UPDATED_DATA][self._thing.name]
+        if status:
+            return status.indoor_humidity
+        return None
+
+    @property
     def target_humidity(self):
-        """Return the current temperature."""
+        """Return the target humidity."""
         status = self.hass.data[DOMAIN][UPDATED_DATA][self._thing.name]
         if status:
             return status.target_humidity


### PR DESCRIPTION
Fix humidifier card cannot display current humidity.
![image](https://github.com/qqaatw/JciHitachiHA/assets/15187947/7c739fbd-a2eb-4db6-a1ae-acd01690dfd5)
