### PR TITLE
Add support for 2024.8 FanEntityFeature TURN_ON and TURN_OFF

### DIFF
--- a/custom_components/jcihitachi_tw/fan.py
+++ b/custom_components/jcihitachi_tw/fan.py
@@ -220,6 +220,9 @@ class JciHitachiHeatExchangerFanEntity(JciHitachiEntity, FanEntity):
 
     def calculate_supported_features(self):
         support_flags = 0
+        if self._thing.support_code.Switch != "unsupported":              
+            support_flags |= FanEntityFeature.TURN_ON
+            support_flags |= FanEntityFeature.TURN_OFF
         if self._thing.support_code.FanSpeed != "unsupported":
             support_flags |= FanEntityFeature.SET_SPEED
         if self._thing.support_code.BreathMode != "unsupported":


### PR DESCRIPTION
This is required for the Heat Exchanger to be turned on and off in 2025.1, even though the [blog](https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/) mentions the deprecation will happen in 2025.2.