### PR TITLE
Add country code to hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,4 @@
 {
-  "name": "JciHitachiHA"
+  "name": "JciHitachiHA",
+  "country": "TW"
 }


### PR DESCRIPTION
As requested by upstream, country specific integrations needs to have a country code in hacs.json. See https://github.com/hacs/default/pull/3433