### PR TITLE
Fix deprecated light feature flags by migrating to color mode API

### DIFF
--- a/custom_components/jcihitachi_tw/light.py
+++ b/custom_components/jcihitachi_tw/light.py
@@ -1,7 +1,7 @@
 import logging
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    SUPPORT_BRIGHTNESS,
+    ColorMode,
     LightEntity,
 )
 
@@ -50,8 +50,12 @@ class JciHitachiDehumidifierLightEntity(JciHitachiEntity, LightEntity):
         return f"{self._thing.name} panel LED"
 
     @property
-    def supported_features(self):
-        return SUPPORT_BRIGHTNESS
+    def supported_color_modes(self):
+        return {ColorMode.BRIGHTNESS}
+
+    @property
+    def color_mode(self):
+        return ColorMode.BRIGHTNESS
 
     @property
     def is_on(self):


### PR DESCRIPTION
  ## Summary

  This PR updates the light platform in jcihitachi_tw to align with Home Assistant’s modern light entity API and avoid deprecated constants removed in newer HA Core versions. (>=2026.3.0)

  ## Changes

  - Replaced deprecated SUPPORT_BRIGHTNESS import from homeassistant.components.light.
  - Switched from supported_features to:
      - supported_color_modes returning {ColorMode.BRIGHTNESS}
      - color_mode returning ColorMode.BRIGHTNESS

  ## Validation

  - Tested with dehumidifier model RD-320HH.
  - Verified LED panel light brightness can be changed successfully through HA, and changes from the dehumidifier is also reflected in HA.

  ## Impact

  - No behavior change intended for end users.
  - Maintains brightness-capable light behavior while using current HA API conventions.