### PR TITLE
Add multi-language support for English and Traditional Chinese

### DIFF
--- a/custom_components/jcihitachi_tw/binary_sensor.py
+++ b/custom_components/jcihitachi_tw/binary_sensor.py
@@ -32,11 +32,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 class JciHitachiErrorBinarySensorEntity(JciHitachiEntity, BinarySensorEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Error"
+        self._attr_translation_key = "error_binary_sensor"
 
     @property
     def is_on(self):
@@ -61,11 +57,7 @@ class JciHitachiErrorBinarySensorEntity(JciHitachiEntity, BinarySensorEntity):
 class JciHitachiWaterFullBinarySensorEntity(JciHitachiEntity, BinarySensorEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Water Full Warning"
+        self._attr_translation_key = "water_full_binary_sensor"
 
     @property
     def is_on(self):

--- a/custom_components/jcihitachi_tw/fan.py
+++ b/custom_components/jcihitachi_tw/fan.py
@@ -50,11 +50,7 @@ class JciHitachiDehumidifierFanEntity(JciHitachiEntity, FanEntity):
         super().__init__(thing, coordinator)
         self._supported_features = self.calculate_supported_features()
         self._supported_fan_speeds = self.calculate_supported_fan_speeds()
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Air Speed"
+        self._attr_translation_key = "dehumidifier_air_speed_fan"
 
     @property
     def supported_features(self):
@@ -167,11 +163,7 @@ class JciHitachiHeatExchangerFanEntity(JciHitachiEntity, FanEntity):
         self._supported_features = self.calculate_supported_features()
         self._supported_fan_speeds = self.calculate_supported_fan_speeds()
         self._supported_presets = self.calculate_supported_presets()
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Air Speed"
+        self._attr_translation_key = "heat_exchanger_air_speed_fan"
 
     @property
     def supported_features(self):

--- a/custom_components/jcihitachi_tw/humidifier.py
+++ b/custom_components/jcihitachi_tw/humidifier.py
@@ -9,14 +9,14 @@ from . import API, COORDINATOR, DOMAIN, UPDATED_DATA, JciHitachiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-MODE_AUTO = "Auto"
-MODE_CUSTOM = "Custom"
-MODE_CONTINUOUS = "Continuous"
-MODE_CLOTHES_DRY = "Clothes Dry"
-MODE_AIR_PURIFY = "Air Purify"
-MODE_MOLD_PREV = "Mold Prev"
-MODE_LOW_HUMIDITY = "Low Humidity"
-MODE_ECO_COMFORT = "Eco Comfort"
+MODE_AUTO = "auto"
+MODE_CUSTOM = "custom"
+MODE_CONTINUOUS = "continuous"
+MODE_CLOTHES_DRY = "clothes_dry"
+MODE_AIR_PURIFY = "air_purify"
+MODE_MOLD_PREV = "mold_prev"
+MODE_LOW_HUMIDITY = "low_humidity"
+MODE_ECO_COMFORT = "eco_comfort"
 
 AVAILABLE_MODES = [
     MODE_AUTO,
@@ -62,6 +62,7 @@ class JciHitachiDehumidifierEntity(JciHitachiEntity, HumidifierEntity):
         super().__init__(thing, coordinator)
         self._supported_features = supported_features
         self._available_modes = [mode for i, mode in enumerate(AVAILABLE_MODES) if 2 ** i & self._thing.support_code.Mode != 0]
+        self._attr_translation_key = "dehumidifier_humidifier"
 
     @property
     def supported_features(self):
@@ -100,22 +101,7 @@ class JciHitachiDehumidifierEntity(JciHitachiEntity, HumidifierEntity):
     def mode(self):
         status = self.hass.data[DOMAIN][UPDATED_DATA][self._thing.name]
         if status:
-            if status.mode == "auto":
-                return MODE_AUTO
-            elif status.mode == "custom":
-                return MODE_CUSTOM
-            elif status.mode == "continuous":
-                return MODE_CONTINUOUS
-            elif status.mode == "clothes_dry":
-                return MODE_CLOTHES_DRY
-            elif status.mode == "air_purify":
-                return MODE_AIR_PURIFY
-            elif status.mode == "mold_prev":
-                return MODE_MOLD_PREV
-            elif status.mode == "low_humidity":
-                return MODE_LOW_HUMIDITY
-            elif status.mode == "eco_comfort":
-                return MODE_ECO_COMFORT
+            return status.mode
 
         _LOGGER.error("Missing mode.")
         return None
@@ -154,22 +140,9 @@ class JciHitachiDehumidifierEntity(JciHitachiEntity, HumidifierEntity):
 
         _LOGGER.debug(f"Set {self.name} mode to {mode}")
 
-        if mode == MODE_AUTO:
-            self.put_queue(status_name="mode", status_str_value="auto")
-        elif mode == MODE_CUSTOM:
-            self.put_queue(status_name="mode", status_str_value="custom")
-        elif mode == MODE_CONTINUOUS:
-            self.put_queue(status_name="mode", status_str_value="continuous")
-        elif mode == MODE_CLOTHES_DRY:
-            self.put_queue(status_name="mode", status_str_value="clothes_dry")
-        elif mode == MODE_AIR_PURIFY:
-            self.put_queue(status_name="mode", status_str_value="air_purify")
-        elif mode == MODE_MOLD_PREV:
-            self.put_queue(status_name="mode", status_str_value="mold_prev")
-        elif mode == MODE_LOW_HUMIDITY:
-            self.put_queue(status_name="mode", status_str_value="low_humidity")
-        elif mode == MODE_ECO_COMFORT:
-            self.put_queue(status_name="mode", status_str_value="eco_comfort")
+        if mode in [MODE_AUTO, MODE_CUSTOM, MODE_CONTINUOUS, MODE_CLOTHES_DRY,
+                    MODE_AIR_PURIFY, MODE_MOLD_PREV, MODE_LOW_HUMIDITY, MODE_ECO_COMFORT]:
+            self.put_queue(status_name="mode", status_str_value=mode)
         else:
             _LOGGER.error("Invalid mode.")
         self.update()

--- a/custom_components/jcihitachi_tw/light.py
+++ b/custom_components/jcihitachi_tw/light.py
@@ -4,6 +4,7 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntity,
 )
+from homeassistant.helpers.entity import EntityDescription
 
 from . import API, COORDINATOR, DOMAIN, UPDATED_DATA, JciHitachiEntity
 
@@ -40,14 +41,11 @@ class JciHitachiDehumidifierLightEntity(JciHitachiEntity, LightEntity):
 
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
+        self._attr_translation_key = "dehumidifier_light"
 
     @property
     def unique_id(self):
         return f"{self._thing.gateway_mac_address}_dehumidifier_light"
-
-    @property
-    def name(self):
-        return f"{self._thing.name} panel LED"
 
     @property
     def supported_color_modes(self):

--- a/custom_components/jcihitachi_tw/number.py
+++ b/custom_components/jcihitachi_tw/number.py
@@ -31,12 +31,8 @@ class JciHitachiMonthlyDataSelectorNumberEntity(JciHitachiEntity, NumberEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
         self._value = 0
+        self._attr_translation_key = "month_selector_number"
 
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Month Selector"
-    
     @property
     def native_value(self):
         """Return the value of the entity."""

--- a/custom_components/jcihitachi_tw/sensor.py
+++ b/custom_components/jcihitachi_tw/sensor.py
@@ -62,11 +62,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 class JciHitachiIndoorHumiditySensorEntity(JciHitachiEntity, SensorEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Indoor Humidity"
+        self._attr_translation_key = "indoor_humidity_sensor"
 
     @property
     def native_value(self):
@@ -94,11 +90,7 @@ class JciHitachiIndoorHumiditySensorEntity(JciHitachiEntity, SensorEntity):
 class JciHitachiPM25SensorEntity(JciHitachiEntity, SensorEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} PM2.5"
+        self._attr_translation_key = "pm25_sensor"
 
     @property
     def native_value(self):
@@ -126,11 +118,7 @@ class JciHitachiPM25SensorEntity(JciHitachiEntity, SensorEntity):
 class JciHitachiOdorLevelSensorEntity(JciHitachiEntity, SensorEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Odor Level"
+        self._attr_translation_key = "odor_level_sensor"
 
     @property
     def native_value(self):
@@ -163,11 +151,7 @@ class JciHitachiOdorLevelSensorEntity(JciHitachiEntity, SensorEntity):
 class JciHitachiPowerConsumptionSensorEntity(JciHitachiEntity, SensorEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Power Consumption"
+        self._attr_translation_key = "power_consumption_sensor"
 
     @property
     def native_value(self):
@@ -198,11 +182,7 @@ class JciHitachiPowerConsumptionSensorEntity(JciHitachiEntity, SensorEntity):
 class JciHitachiMonthlyPowerConsumptionSensorEntity(JciHitachiEntity, SensorEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Monthly Power Consumption"
+        self._attr_translation_key = "monthly_power_consumption_sensor"
 
     @property
     def native_value(self):
@@ -233,11 +213,7 @@ class JciHitachiMonthlyPowerConsumptionSensorEntity(JciHitachiEntity, SensorEnti
 class JciHitachiMonthIndicatorSensorEntity(JciHitachiEntity, SensorEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Month Indicator"
+        self._attr_translation_key = "month_indicator_sensor"
 
     @property
     def state(self):
@@ -268,11 +244,7 @@ class JciHitachiMonthIndicatorSensorEntity(JciHitachiEntity, SensorEntity):
 class JciHitachiIndoorTemperatureSensorEntity(JciHitachiEntity, SensorEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Indoor Temperature"
+        self._attr_translation_key = "indoor_temperature_sensor"
 
     @property
     def native_value(self):

--- a/custom_components/jcihitachi_tw/switch.py
+++ b/custom_components/jcihitachi_tw/switch.py
@@ -35,11 +35,7 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
 class JciHitachiAirCleaningFilterEntity(JciHitachiEntity, SwitchEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Air Cleaning Filter Setting"
+        self._attr_translation_key = "air_cleaning_filter_switch"
 
     @property
     def is_on(self):
@@ -72,11 +68,7 @@ class JciHitachiAirCleaningFilterEntity(JciHitachiEntity, SwitchEntity):
 class JciHitachiCleanFilterNotifySwitchEntity(JciHitachiEntity, SwitchEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Clean Filter Notification"
+        self._attr_translation_key = "clean_filter_notify_switch"
 
     @property
     def is_on(self):
@@ -109,11 +101,7 @@ class JciHitachiCleanFilterNotifySwitchEntity(JciHitachiEntity, SwitchEntity):
 class JciHitachiMoldPrevSwitchEntity(JciHitachiEntity, SwitchEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Mold Prevention"
+        self._attr_translation_key = "mold_prev_switch"
 
     @property
     def is_on(self):
@@ -146,11 +134,7 @@ class JciHitachiMoldPrevSwitchEntity(JciHitachiEntity, SwitchEntity):
 class JciHitachiWindSwingableSwitchEntity(JciHitachiEntity, SwitchEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Wind Swingable"
+        self._attr_translation_key = "wind_swingable_switch"
 
     @property
     def is_on(self):
@@ -182,11 +166,7 @@ class JciHitachiWindSwingableSwitchEntity(JciHitachiEntity, SwitchEntity):
 class JciHitachiIonSwitchEntity(JciHitachiEntity, SwitchEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Ion"
+        self._attr_translation_key = "ion_switch"
 
     @property
     def is_on(self):
@@ -218,11 +198,7 @@ class JciHitachiIonSwitchEntity(JciHitachiEntity, SwitchEntity):
 class JciHitachiKeypadLockSwitchEntity(JciHitachiEntity, SwitchEntity):
     def __init__(self, thing, coordinator):
         super().__init__(thing, coordinator)
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return f"{self._thing.name} Keypad Lock"
+        self._attr_translation_key = "keypad_lock_switch"
 
     @property
     def is_on(self):

--- a/custom_components/jcihitachi_tw/translations/en.json
+++ b/custom_components/jcihitachi_tw/translations/en.json
@@ -21,10 +21,101 @@
         "error": {
             "assertion_check_error": "The device(s) you specified is/are not available from the API.",
             "login_error": "Incorrect email or password.",
-            "unknown_error": "Unknown error occurred."            
+            "unknown_error": "Unknown error occurred."
         },
         "abort": {
             "already_configured": "Device already configured"
+        }
+    },
+    "entity": {
+        "sensor": {
+            "indoor_humidity_sensor": {
+                "name": "Indoor Humidity"
+            },
+            "pm25_sensor": {
+                "name": "PM2.5"
+            },
+            "odor_level_sensor": {
+                "name": "Odor Level"
+            },
+            "power_consumption_sensor": {
+                "name": "Power Consumption"
+            },
+            "monthly_power_consumption_sensor": {
+                "name": "Monthly Power Consumption"
+            },
+            "month_indicator_sensor": {
+                "name": "Month Indicator"
+            },
+            "indoor_temperature_sensor": {
+                "name": "Indoor Temperature"
+            }
+        },
+        "binary_sensor": {
+            "error_binary_sensor": {
+                "name": "Error"
+            },
+            "water_full_binary_sensor": {
+                "name": "Water Full Warning"
+            }
+        },
+        "light": {
+            "dehumidifier_light": {
+                "name": "Panel LED"
+            }
+        },
+        "fan": {
+            "dehumidifier_air_speed_fan": {
+                "name": "Air Speed"
+            },
+            "heat_exchanger_air_speed_fan": {
+                "name": "Air Speed"
+            }
+        },
+        "switch": {
+            "air_cleaning_filter_switch": {
+                "name": "Air Cleaning Filter Setting"
+            },
+            "clean_filter_notify_switch": {
+                "name": "Clean Filter Notification"
+            },
+            "mold_prev_switch": {
+                "name": "Mold Prevention"
+            },
+            "wind_swingable_switch": {
+                "name": "Wind Swingable"
+            },
+            "ion_switch": {
+                "name": "Ion"
+            },
+            "keypad_lock_switch": {
+                "name": "Keypad Lock"
+            }
+        },
+        "number": {
+            "month_selector_number": {
+                "name": "Month Selector"
+            }
+        },
+        "humidifier": {
+            "dehumidifier_humidifier": {
+                "name": "Dehumidifier",
+                "state_attributes": {
+                    "mode": {
+                        "name": "Mode",
+                        "state": {
+                            "auto": "Auto",
+                            "custom": "Custom",
+                            "continuous": "Continuous",
+                            "clothes_dry": "Clothes Dry",
+                            "air_purify": "Air Purify",
+                            "mold_prev": "Mold Prev",
+                            "low_humidity": "Low Humidity",
+                            "eco_comfort": "Eco Comfort"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/custom_components/jcihitachi_tw/translations/zh-Hant.json
+++ b/custom_components/jcihitachi_tw/translations/zh-Hant.json
@@ -1,0 +1,121 @@
+{
+    "config": {
+        "flow_title": "JciHitachi TW",
+        "step": {
+            "user": {
+                "data": {
+                    "email": "JciHitachi 電子郵件",
+                    "password": "JciHitachi 密碼",
+                    "retry": "命令發送失敗時的重試次數",
+                    "devices": "裝置名稱 (留空以自動從 API 檢索)",
+                    "add_another_device": "添加另一個裝置？"
+                }
+            },
+            "add_device": {
+                "data": {
+                    "devices": "裝置名稱 (留空以自動從 API 檢索)",
+                    "add_another_device": "添加另一個裝置？"
+                }
+            }
+        },
+        "error": {
+            "assertion_check_error": "您指定的裝置不可從 API 獲得。",
+            "login_error": "電子郵件或密碼不正確。",
+            "unknown_error": "發生未知錯誤。"
+        },
+        "abort": {
+            "already_configured": "裝置已配置"
+        }
+    },
+    "entity": {
+        "sensor": {
+            "indoor_humidity_sensor": {
+                "name": "室內濕度"
+            },
+            "pm25_sensor": {
+                "name": "PM2.5"
+            },
+            "odor_level_sensor": {
+                "name": "異味等級"
+            },
+            "power_consumption_sensor": {
+                "name": "電力消耗"
+            },
+            "monthly_power_consumption_sensor": {
+                "name": "月度電力消耗"
+            },
+            "month_indicator_sensor": {
+                "name": "月份指示器"
+            },
+            "indoor_temperature_sensor": {
+                "name": "室內溫度"
+            }
+        },
+        "binary_sensor": {
+            "error_binary_sensor": {
+                "name": "錯誤"
+            },
+            "water_full_binary_sensor": {
+                "name": "水滿警告"
+            }
+        },
+        "light": {
+            "dehumidifier_light": {
+                "name": "面板 LED"
+            }
+        },
+        "fan": {
+            "dehumidifier_air_speed_fan": {
+                "name": "風速"
+            },
+            "heat_exchanger_air_speed_fan": {
+                "name": "風速"
+            }
+        },
+        "switch": {
+            "air_cleaning_filter_switch": {
+                "name": "空氣淨化濾網設置"
+            },
+            "clean_filter_notify_switch": {
+                "name": "清潔濾網通知"
+            },
+            "mold_prev_switch": {
+                "name": "防黴"
+            },
+            "wind_swingable_switch": {
+                "name": "風向擺動"
+            },
+            "ion_switch": {
+                "name": "負離子"
+            },
+            "keypad_lock_switch": {
+                "name": "按鍵鎖定"
+            }
+        },
+        "number": {
+            "month_selector_number": {
+                "name": "月份選擇器"
+            }
+        },
+        "humidifier": {
+            "dehumidifier_humidifier": {
+                "name": "除濕機",
+                "state_attributes": {
+                    "mode": {
+                        "name": "運作模式",
+                        "state": {
+                            "auto": "自動",
+                            "custom": "自訂",
+                            "continuous": "連續",
+                            "clothes_dry": "衣物乾燥",
+                            "air_purify": "空氣淨化",
+                            "mold_prev": "防黴",
+                            "low_humidity": "低濕度",
+                            "eco_comfort": "舒適節能"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/custom_components/jcihitachi_tw/translations/zh-Hant.json
+++ b/custom_components/jcihitachi_tw/translations/zh-Hant.json
@@ -80,7 +80,7 @@
                 "name": "清潔濾網通知"
             },
             "mold_prev_switch": {
-                "name": "防黴"
+                "name": "防霉"
             },
             "wind_swingable_switch": {
                 "name": "風向擺動"
@@ -109,7 +109,7 @@
                             "continuous": "連續",
                             "clothes_dry": "衣物乾燥",
                             "air_purify": "空氣淨化",
-                            "mold_prev": "防黴",
+                            "mold_prev": "防霉",
                             "low_humidity": "低濕度",
                             "eco_comfort": "舒適節能"
                         }


### PR DESCRIPTION
- Implement translation keys for all entity names (sensors, binary sensors, lights, fans, switches, numbers)
- Add Traditional Chinese translation file (zh-Hant.json) with complete UI translations
- Update English translation file (en.json) with proper entity translation structure
- Replace hardcoded entity names with translation_key attributes for automatic localization
- Support Home Assistant's built-in language selection system